### PR TITLE
Fix Node Setup Script

### DIFF
--- a/scripts/setup_one_node.sh
+++ b/scripts/setup_one_node.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -Eeuo pipefail
 
 # Run from Cloudlab
 # git clone https://github.com/MaoZiming/Trinity.git
@@ -37,7 +38,7 @@ sudo make install
 cd $dependencies_path
 
 # Install thrift
-if [ ! -d "thrift"]; then
+if [ ! -d "thrift" ]; then
     git clone https://github.com/apache/thrift.git
     cd thrift
     ./bootstrap.sh

--- a/scripts/setup_one_node.sh
+++ b/scripts/setup_one_node.sh
@@ -59,3 +59,4 @@ sudo apt-get install -y libbz2-dev
 sudo apt-get install -y python3-dev  # for python3.x installs
 sudo apt-get install -y libevent-dev
 sudo apt-get install -y clang-format
+sudo apt-get install -y flex bison

--- a/scripts/setup_one_node.sh
+++ b/scripts/setup_one_node.sh
@@ -11,8 +11,9 @@ dependencies_path="/proj/trinity-PG0/dependencies"
 # Basic setup
 sudo apt update
 # sudo apt upgrade
-sudo apt install htop
-sudo apt-get install dstat
+sudo apt install -y htop
+sudo apt install -y dstat
+sudo apt install -y pkgconf  # making thrift requires this
 cd $dependencies_path
 
 # Install Cmake

--- a/scripts/setup_one_node.sh
+++ b/scripts/setup_one_node.sh
@@ -40,7 +40,9 @@ cd $dependencies_path
 
 # Install thrift
 if [ ! -d "thrift" ]; then
-    git clone https://github.com/apache/thrift.git
+    wget -nc https://dlcdn.apache.org/thrift/0.20.0/thrift-0.20.0.tar.gz
+    tar -xvf thrift-0.20.0.tar.gz
+    mv thrift-0.20.0 thrift
     cd thrift
     ./bootstrap.sh
     sudo ./configure --without-erlang


### PR DESCRIPTION
Thanks for the great work, enjoyed reading your paper :D 

This PR includes 4 fixes:

46153ef31b1bd683943b520fdf45133847c95ac4 fixes the following error:

```bash
~/Trinity/build$ cat thrift_ep-prefix/src/thrift_ep-stamp/thrift_ep-configure-*.log
CMake Error at /usr/share/cmake-3.23/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find BISON (missing: BISON_EXECUTABLE)
```
(and similarly for `flex`)

ced22d5c18cebff04b7c4dc67228dea4a21b3c21 fixes a missing space that caused the `if` test for the Thrift installation to fail. It also adds `set -Eeuo pipefail` to the top of the script to ensure the script fails fast in case of an error like this, as a precaution.

```
-bash: [: missing `]'
```

c3a704fca140a4efc1e774026a6e7dde111005a9 installs `pkgconf` as a dependency for compiling Thrift. See: https://issues.apache.org/jira/browse/THRIFT-4910

82e3ade344c5e454e8e38dbc25083a626b550c1d switches to using a stable release of Thrift (I randomly selected the latest 0.20.0, which seems to work well with the Trinity compilation) to avoid [a bug](https://github.com/apache/thrift/pull/2968) in the current git main branch of Thrift, and to ensure the script installs a version of Thrift that is confirmed to work with Trinity, instead of always opting for the latest commit.